### PR TITLE
set `provides` to resources for compatibility with Chef Infra Client >= 16.2

### DIFF
--- a/resources/docker_compose_deployment.rb
+++ b/resources/docker_compose_deployment.rb
@@ -1,4 +1,5 @@
 resource_name :docker_compose_deployment
+provides :docker_compose_deployment
 
 actions :create, :start, :stop, :delete, :rm, :restart, :pull, :push, :up, :down, :kill, :scale
 default_action :up

--- a/resources/docker_compose_installation.rb
+++ b/resources/docker_compose_installation.rb
@@ -1,4 +1,5 @@
 resource_name :docker_compose_installation
+provides :docker_compose_installation
 
 actions :install, :delete, :create, :remove
 default_action :install


### PR DESCRIPTION
Hi,

https://docs.chef.io/release_notes/#whats-new-in-162

Since Chef Infra Client version 16.2, custom resources have been defined with the The `resource_name` is no longer referenced.
I've add `provides` declarations for compatibility, since they could be written together.